### PR TITLE
Add configuration-service to the docker-compose stack.  Update exam-s…

### DIFF
--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -50,10 +50,10 @@ services:
         condition: service_started
       config:
         condition: service_started
+    env_file:
+      - tds-common.env
+      - exam.env
     environment:
-      - CONFIG_SERVICE_URL=http://configuration-service:8888
-      - CONFIG_SERVICE_ENABLED=true
-      - SPRING_PROFILES_ACTIVE=local-docker
       # Define these in your host machine environment
       - MYSQL_URL
       - MYSQL_USER

--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -1,5 +1,20 @@
-version:  '2'
+version:  '2.1'
 services:
+  configuration-service:
+    image: fwsbac/configuration-service
+    ports:
+      - "32844:8888"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/health.json"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    environment:
+      # Define these in your host machine environment
+      - CONFIG_SERVICE_REPO
+      - GIT_USER
+      - GIT_PASSWORD
+      - ENCRYPT_KEY
   student:
     image: fwsbac/tds-student-service
     ports:
@@ -20,25 +35,26 @@ services:
     ports:
       - "32843:8080"
     env_file: tds-docker.env
-  exam_mysql:
-    image: mysql
-    ports:
-      - "32777:3306"
-    volumes_from:
-      - exam_mysql_data
-    env_file: tds-docker.env
-  exam_mysql_data:
-    image: mysql
-    entrypoint: /bin/bash
   exam:
     image: fwsbac/tds-exam-service
     ports:
       - "80:8080"
     depends_on:
-      - assessment
-      - session
-      - student
-      - config
-      - exam_mysql
-    env_file:
-      - ./tds-docker.env
+      configuration-service:
+        condition: service_healthy
+      assessment:
+        condition: service_started
+      session:
+        condition: service_started
+      student:
+        condition: service_started
+      config:
+        condition: service_started
+    environment:
+      - CONFIG_SERVICE_URL=http://configuration-service:8888
+      - CONFIG_SERVICE_ENABLED=true
+      - SPRING_PROFILES_ACTIVE=local-docker
+      # Define these in your host machine environment
+      - MYSQL_URL
+      - MYSQL_USER
+      - MYSQL_PASSWORD

--- a/docker/tds/exam.env
+++ b/docker/tds/exam.env
@@ -1,0 +1,2 @@
+# Active profiles when loading the exam service in docker-compose
+SPRING_PROFILES_ACTIVE=local-docker

--- a/docker/tds/tds-common.env
+++ b/docker/tds/tds-common.env
@@ -1,0 +1,3 @@
+# Common environment properties for all services
+CONFIG_SERVICE_URL=http://configuration-service:8888
+CONFIG_SERVICE_ENABLED=true


### PR DESCRIPTION
…ervice configuration to pull remote configuration properties.

This PR changes our docker-compose.yml to:
* stand up a configuration-service
* remove the mysql container
* update the exam-service configurations to use external configurations

There is a [related pull request](https://github.com/SmarterApp/TDS_ExamService/pull/72) for the exam service.