### PR TITLE
Update environment properties for sharing across services.

### DIFF
--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -55,6 +55,6 @@ services:
       - exam.env
     environment:
       # Define these in your host machine environment
-      - MYSQL_URL
-      - MYSQL_USER
-      - MYSQL_PASSWORD
+      - SBAC_JDBC_HOST
+      - SBAC_JDBC_USER
+      - SBAC_JDBC_PASSWORD


### PR DESCRIPTION
Now that we have multiple services, each connecting to different databases, having an environment property *ONLY* for /exam doesn't make a lot of sense.  I also took this opportunity to rename the environment properties to be slightly more generic.

See the changes in https://confluence.fairwaytech.com/display/SBAC1719/Docker+Usage#DockerUsage-InitialSetup