### PR TITLE
Externalize assessment configs

### DIFF
--- a/docker/tds/assessment.env
+++ b/docker/tds/assessment.env
@@ -1,0 +1,2 @@
+# Active profiles when loading the assessment service in docker-compose
+SPRING_PROFILES_ACTIVE=local-docker

--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -24,7 +24,17 @@ services:
     image: fwsbac/tds-assessment-service
     ports:
       - "32841:8080"
-    env_file: tds-docker.env
+    depends_on:
+      configuration-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    env_file:
+      - tds-common.env
+      - assessment.env
   session:
     image: fwsbac/tds-session-service
     ports:


### PR DESCRIPTION
This PR updates the docker-compose deployment descriptor to wire the assessment-service into the configuration-service for providing externalized configuration properties.