### PR TITLE
Externalize configuration properties for the session-service

### DIFF
--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -39,7 +39,17 @@ services:
     image: fwsbac/tds-session-service
     ports:
       - "32842:8080"
-    env_file: tds-docker.env
+    depends_on:
+      configuration-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    env_file:
+      - tds-common.env
+      - session.env
   config:
     image: fwsbac/tds-config-service
     ports:

--- a/docker/tds/session.env
+++ b/docker/tds/session.env
@@ -1,0 +1,2 @@
+# Active profiles when loading the session service in docker-compose
+SPRING_PROFILES_ACTIVE=local-docker


### PR DESCRIPTION
Update the docker-compose definition to wire the session-service into the configuration-service for externalized configuration properties.