### PR TITLE
Add rabbit

### DIFF
--- a/docker/tds/docker-compose.yml
+++ b/docker/tds/docker-compose.yml
@@ -3,14 +3,18 @@ services:
   # SPRING CLOUD CONFIGURATION SERVICE
   configuration-service:
     image: fwsbac/configuration-service
+    depends_on:
+      rabbit:
+        condition: service_healthy
     ports:
       - "32844:8888"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8888/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     environment:
+      - SPRING_RABBITMQ_HOST=rabbit
       # Define these in your host machine environment
       - CONFIG_SERVICE_REPO
       - GIT_USER
@@ -28,9 +32,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     env_file:
       - tds-common.env
       - student.env
@@ -47,9 +51,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     env_file:
       - tds-common.env
       - assessment.env
@@ -66,9 +70,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     env_file:
       - tds-common.env
       - session.env
@@ -85,9 +89,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     env_file:
       - tds-common.env
       - config.env
@@ -118,9 +122,9 @@ services:
         condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health.json"]
-      interval: 30s
+      interval: 15s
       timeout: 10s
-      retries: 5
+      retries: 10
     env_file:
       - tds-common.env
       - exam.env
@@ -130,4 +134,18 @@ services:
       - SBAC_JDBC_USER
       - SBAC_JDBC_PASSWORD
       - JAVA_OPTS=${CONTAINER_JAVA_OPTS}
+
+  #RabbitMQ Broker
+  rabbit:
+    image: rabbitmq:3.6.9-alpine
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+    ports:
+      - "32846:5672"
+    environment:
+      - RABBITMQ_LOGS="-"
+      - RABBITMQ_SASL_LOGS="-"
 

--- a/docker/tds/tds-common.env
+++ b/docker/tds/tds-common.env
@@ -1,3 +1,4 @@
 # Common environment properties for all services
 CONFIG_SERVICE_URL=http://configuration-service:8888
 CONFIG_SERVICE_ENABLED=true
+SPRING_RABBITMQ_HOST=rabbit


### PR DESCRIPTION
This PR adds a rabbitmq server to our docker-compose environment.  This is currently needed by the configuration service and will soon be required by all of our microservices to be notified of configuration changes.

NOTE:
This is a required update to run the latest configuration-service.